### PR TITLE
Fix cache directory reference to work in environments such as Engine Yard

### DIFF
--- a/bin/bcms
+++ b/bin/bcms
@@ -108,7 +108,7 @@ CODE
     insert_into_file "config/environments/production.rb", :after => "Application.configure do\n" do
       <<-CODE
   config.action_view.cache_template_loading = false
-  config.action_controller.page_cache_directory = Rails.root + '/public/cache/'
+  config.action_controller.page_cache_directory = File.join(Rails.root,'public','cache')
       CODE
     end
   end


### PR DESCRIPTION
It seems that the current cache page doesn't work on Engine Yard, meaning BCMS cannot create the directories and files needed for caching.

Changing the declaration to a File.join call makes this a little more resilient.
