### PR TITLE
Fix a major pluralization bug in ContentType.find_by_key

### DIFF
--- a/app/models/cms/content_type.rb
+++ b/app/models/cms/content_type.rb
@@ -19,7 +19,7 @@ module Cms
     # Given a 'key' like 'html_blocks' or 'portlet'
     # Raises exception if nothing was found.
     def self.find_by_key(key)
-      class_name = key.tableize.classify
+      class_name = key.singularize.tableize.classify
       content_type = find(:first, :conditions => ["name like ?", "%#{class_name}"])
       if content_type.nil?
         if class_name.constantize.ancestors.include?(Cms::Portlet)


### PR DESCRIPTION
"tableize" expects a singular noun.If you create a ContentType named
"Person", or I would imagine any irregular pluralization,
ContentType.find_by_key won't be able to properly find the singular
content type name on the "content_types" table. This is because block_type 
is passed in as a plural noun when it should be singular.

bcms will throw an unfriendly error and adding the existing content will fail.

Here's why:

"people".tableize == "peoples" <-- BAD
"people".tableize.classify == "People" <-- BAD! Needs to be singular.

"people".singularize == "person" <-- GOOD!
"people".singularize.tableize.classify == "Person" <-- GOOD!

This most commonly occurs when accessing:

/cms/connectors/new?page_id=1&container=main&block_type=<block type>
