### PR TITLE
Add remove_content_column method

### DIFF
--- a/lib/cms/extensions/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/lib/cms/extensions/active_record/connection_adapters/abstract/schema_statements.rb
@@ -110,6 +110,11 @@ module ActiveRecord
         add_column "#{table_name.to_s.singularize}_versions".to_sym, column_name, type, options
       end
 
+      def remove_content_column(table_name, column_name)
+        remove_column table_name, column_name
+        remove_column "#{table_name.to_s.singularize}_versions".to_sym, column_name
+      end
+
       # Will namespace the content table
       def content_table_exists?(table_name)
         table_exists?(Cms::Namespacing.prefixed_table_name(table_name))


### PR DESCRIPTION
BrowserCMS adds a useful wrapper method `add_content_column` to add a column to a table and the corresponding versions table at the same time. This patch adds a `remove_content_column` method to do the same thing but in the opposite way.
