### PR TITLE
monkey patched the cms attachments model to accept an unused value param...

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -178,7 +178,7 @@ class Attachment < ActiveRecord::Base
     section ? section.public? : false
   end
   
-  def full_file_location
+  def full_file_location(param=nil)
     File.join(Attachment.storage_location, file_location)
   end
 


### PR DESCRIPTION
...eter, issue raised by bcms_assets module e monkeypatch requiring the attachment to accept a parameter
