### PR TITLE
fix double eval of dynamic routing

### DIFF
--- a/app/controllers/cms/content_controller.rb
+++ b/app/controllers/cms/content_controller.rb
@@ -67,7 +67,6 @@ module Cms
       @_page_route = PageRoute.find(params[:_page_route_id])
       @path = @_page_route.page.path
       @initial_ivars = instance_variables
-      eval @_page_route.code
     end
 
     def redirect_non_cms_users_to_public_site


### PR DESCRIPTION
PageRoute object was executed twice, once in construct_path_from_route and second in render_page method
