### PR TITLE
File field label should use method as fall back

### DIFF
--- a/app/views/cms/form_builder/_cms_file_field.html.erb
+++ b/app/views/cms/form_builder/_cms_file_field.html.erb
@@ -10,7 +10,7 @@
     <% if a.object.attachment_name == method.to_s %>
         <%= a.hidden_field :attachment_name, :value => method.to_s %>
         <div class="fields file_fields">
-            <%= a.cms_label :data, cms_options[:label] %>
+            <%= a.cms_label method, cms_options[:label] %>
             <div id="<%= object_name %>_<%= method %>_div" class="file_inputs">
                 <%= a.file_field :data, options.merge('data-purpose'=>"cms_file_field") %>
             </div>


### PR DESCRIPTION
If no label text is given, this change makes cms_file_field use the method name instead of 'data'.

`<%= f.cms_file_field :image, :label => "Something" %>` will display "Something".

`<%= f.cms_file_field :image %>` will display "Image".

This behavior is consistent with the other cms fields (and Rails.)
