### PR TITLE
Deleted second curly bracket from production.rb

### DIFF
--- a/bin/bcms
+++ b/bin/bcms
@@ -193,7 +193,7 @@ Cms.table_prefix = "cms_"
   def configure_mail_server
     [
         "# Configure your mail server's address below",
-        "config.action_mailer.smtp_settings = {:address => 'mail.yourmailserver.com', :domain => config.cms.site_domain}}\n"
+        "config.action_mailer.smtp_settings = {:address => 'mail.yourmailserver.com', :domain => config.cms.site_domain}\n"
     ].reverse.each do |line|
       environment line, :env => "production"
     end


### PR DESCRIPTION
Trying to deploy my BrowserCMS project on Heroku, I noticed there were second curly bracket in production.rb that prevented it from working. After further inspection I found it was left there by commit 54caf2c6b7a039e2858914e8d4be14c0fcf23c1e. This seems to be accident.
