### PR TITLE
Small fix for PageHelper to include ostruct so OpenStruct doesn't throw an error.

### DIFF
--- a/lib/cms/acts/content_page.rb
+++ b/lib/cms/acts/content_page.rb
@@ -17,6 +17,7 @@ module Cms
 
     # Override some of the behavior defined in Cms::PageHelper so templates display correctly Rails Controllers
     module PageHelper
+      require 'ostruct' # Required or PageHelper things OpenStruct belongs under the PageHelper module and throws an error.
 
       # Do not show the toolbar on Acts::As::ContentPages
       def cms_toolbar


### PR DESCRIPTION
I was trying to get custom controllers to work with the CMS layouts today and ran into a few issues - the easiest on to fix was that there was an error about a missing constant, OpenStruct, in Cms::Acts::PageHelper.  

This pull request fixes that error by requiring 'ostruct' in the PageHelper module.
