### PR TITLE
Don't require environment or DB during asset compilation

### DIFF
--- a/bin/bcms
+++ b/bin/bcms
@@ -188,7 +188,7 @@ Cms.table_prefix = "cms_"
 
   def enable_asset_precompiling
     gsub_file "config/environments/production.rb", /config\.assets\.compile = false/, 'config.assets.compile = true'
-    gsub_file 'config/application.rb', /^(s*)(config\.assets\.enabled = true)/, <<-RUBY
+    gsub_file 'config/application.rb', /^(\s*)(config\.assets\.enabled = true)/, <<-RUBY
 \1\2
 
 \1# Don't require environment or DB during asset compilation


### PR DESCRIPTION
The default settings cause problems with asset compilation on Heroku and elsewhere -- see https://devcenter.heroku.com/articles/rails-asset-pipeline#troubleshooting -- so I believe this patch will create a more suitable application.rb file.
