### PR TITLE
Allow Cms::PageTemplate to handle templates with one file extension part

### DIFF
--- a/app/models/cms/page_template.rb
+++ b/app/models/cms/page_template.rb
@@ -17,7 +17,8 @@ module Cms
 
     def self.display_name(file_name)
       name, format, handler = file_name.split('.')
-      "#{name.titleize} (#{format}/#{handler})"
+      content_type = handler ? "#{format}/#{handler}" : "#{format}"
+      "#{name.titleize} (#{content_type})"
     end
 
     def self.resource_collection_name

--- a/test/unit/models/page_template_test.rb
+++ b/test/unit/models/page_template_test.rb
@@ -47,4 +47,9 @@ class PageTemplateTest < ActiveSupport::TestCase
   def test_default_body
     assert_not_nil Cms::PageTemplate.default_body
   end
+
+  def test_display_name
+    assert_equal "Foo (html/erb)", Cms::PageTemplate.display_name("foo.html.erb")
+    assert_equal "Foo (slim)", Cms::PageTemplate.display_name("foo.slim")
+  end
 end


### PR DESCRIPTION
Specifically I made this for when I use slim templates as in the test case.
