### PR TITLE
Added support for the s3_host_alias (needed to use Cloudfront)

### DIFF
--- a/app/models/cms/attachment.rb
+++ b/app/models/cms/attachment.rb
@@ -97,7 +97,8 @@ module Cms
                           :whiny => configuration.whiny,
                           :storage => rail_config(:storage),
                           :s3_credentials => rail_config(:s3_credentials),
-                          :bucket => rail_config(:s3_bucket)
+                          :bucket => rail_config(:s3_bucket),
+                          :s3_host_alias => rail_config(:s3_host_alias)
 
       end
 

--- a/lib/cms/attachments/configuration.rb
+++ b/lib/cms/attachments/configuration.rb
@@ -45,7 +45,7 @@ module Cms
 
       # Set default configurations for Attachments.
       def initialize
-        self.url = ":attachment_file_path"
+        self.url = Rails.configuration.cms.attachments[:url] || ":attachment_file_path"
         self.path = ":attachments_root/:id_partition/:style/:fingerprint"
         self.styles = {}
         self.processors = [:thumbnail]


### PR DESCRIPTION
With this, you can configure your app to use Cloudfront (or a CNAME) for your attachment delivery.
Just add these to your configuration : 

```
config.cms.attachments.s3_bucket = "bucket-name"
config.cms.attachments.s3_host_alias = "12345.cloudfront.net"
config.cms.attachments.url = ":s3_alias_url"
```
