### PR TITLE
[#624] Adds JSON response to the tags controller. Fixes bug #624.

### DIFF
--- a/app/assets/javascripts/jquery.taglist.js
+++ b/app/assets/javascripts/jquery.taglist.js
@@ -76,9 +76,11 @@
       switch(event.keyCode) {
         case 38: //Up Arrow
           selectPrevTag()
+          return false
           break;
         case 40: //Down Arrow
           selectNextTag()
+          return false
           break;
         case 9: //Tab
         case 13: //Return
@@ -137,21 +139,17 @@
     
     createEmptyTagList()
     $(this).keydown(handleNavKeys).keyup(handleInput)
-    $(this).blur(function(){getTagList().hide()})
+    $(this).blur(function(){getTagList().fadeOut(200)})
   }
 })(jQuery);
 
 // Autosuggest for tags
-// This does not work and should be refactored to use JSON.
-//$(function(){
-//  $.ajax({
-//    url: '/cms/tags',
-//    dataType: 'json',
-//    success: function(data){
-//      console.log('back');
-//      eval(data);
-//      console.log(tags);
-//      $('.tag_list').tagList(tags);
-//    }
-//  });
-//});
+$(function(){
+  $.ajax({
+    url: '/cms/tags',    
+    dataType: 'json',
+    success: function(data){      
+      $('.tag_list').tagList(data);      
+    }
+  });
+});

--- a/app/controllers/cms/tags_controller.rb
+++ b/app/controllers/cms/tags_controller.rb
@@ -4,7 +4,7 @@ module Cms
       load_blocks
       respond_to do |format|
         format.html
-        format.js { render :inline => "var tags = #{@blocks.map { |e| e.name }.to_json};" }
+        format.json { render :inline => @blocks.map { |e| e.name }.to_json }
       end
     end
 


### PR DESCRIPTION
- Fixes bugs in auto complete tags jQuery function that caused key
  events to fire twice and prevented clicks on tags from firing.
- Adds JSON response to the tags controller.
