### PR TITLE
allow config for: s3_host_name

### DIFF
--- a/app/models/cms/attachment.rb
+++ b/app/models/cms/attachment.rb
@@ -98,6 +98,7 @@ module Cms
                           :storage => rail_config(:storage),
                           :s3_credentials => rail_config(:s3_credentials),
                           :bucket => rail_config(:s3_bucket),
+                          :s3_host_name => rail_config(:s3_host_name),
                           :s3_host_alias => rail_config(:s3_host_alias)
 
       end


### PR DESCRIPTION
Please accept this pull request.
The change enables bcms_s3 to play nice with non-default S3 regions.

For eu_west_1, I must add config:
  config.cms.attachments.s3_host_name = 's3-eu-west-1.amazonaws.com'
