### PR TITLE
fix error reporting on attempting to save content_block instances

### DIFF
--- a/app/views/cms/application/_exception.html.erb
+++ b/app/views/cms/application/_exception.html.erb
@@ -1,6 +1,6 @@
 <div class="errorExplanation" id="errorExplanation">
   <h2>An Error Occurred</h2>
   <ul>
-    <li><%=h "#{exception.class.name}: #{exception.message}" %></li>
+    <li><%=h "#{@exception.class.name}: #{@exception.message}" %></li>
   </ul>
 </div>


### PR DESCRIPTION
Please accept this pull request.
It fixes rendering the exception partial when errors occur when updating models.
