### PR TITLE
use named wrapper config for simple_form

### DIFF
--- a/app/helpers/cms/form_tag_helper.rb
+++ b/app/helpers/cms/form_tag_helper.rb
@@ -8,7 +8,7 @@ module Cms
     # support.
     def content_block_form_for(object, *args, &block)
       options = args.extract_options!
-      simple_form_for(engine_aware_path(object), *(args << options.merge(builder: Cms::FormBuilder::ContentBlockFormBuilder)), &block)
+      simple_form_for(engine_aware_path(object), *(args << options.merge(builder: Cms::FormBuilder::ContentBlockFormBuilder, wrapper: 'browsercms')), &block)
     end
 
 

--- a/lib/cms/configure_simple_form_bootstrap.rb
+++ b/lib/cms/configure_simple_form_bootstrap.rb
@@ -9,6 +9,15 @@ SimpleForm.setup do |config|
     b.use :hint, wrap_with: {tag: 'p', class: 'help-block'}
   end
 
+  config.wrappers :browsercms, tag: 'div', class: 'control-group row-fluid', error_class: 'error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.use :label
+    b.use :input
+    b.use :error, wrap_with: {tag: 'span', class: 'help-inline'}
+    b.use :hint, wrap_with: {tag: 'p', class: 'help-block'}
+  end
+
   config.wrappers :checkbox, :tag => 'div', :class => 'control-group row-fluid', :error_class => 'error' do |b|
     b.use :html5
     b.use :placeholder


### PR DESCRIPTION
This pull request covers:
- BrowserCms content-block forms use a named simple forms config.
- The host app can then use a different default config.

When using SimpleForm in the host app, if the included wrapper config in lib/cms/configure_simple_form_bootstrap.rb is not sufficient, a simple_forms initialiser should be added, and a copy of the browsercms wrapper config element added to that.
