### PR TITLE
enable publish 1st draft on save, when no changes

### DIFF
--- a/lib/cms/behaviors/versioning.rb
+++ b/lib/cms/behaviors/versioning.rb
@@ -220,8 +220,13 @@ module Cms
           self.skip_callbacks = false
           unless different_from_last_draft?
             logger.debug { "No difference between this version and last. Skipping save" }
-            self.skip_callbacks = true
-            return true
+            if !published && publish_on_save
+              logger.debug { "Publishing current draft version" }
+              return publish
+            else
+              self.skip_callbacks = true
+              return true
+            end
           end
           logger.debug { "Saving #{self.class} #{self.attributes}" }
           if new_record?

--- a/test/unit/behaviors/publishing_mini_test.rb
+++ b/test/unit/behaviors/publishing_mini_test.rb
@@ -64,6 +64,12 @@ describe 'Publishing' do
       draft_block.versions.size.must_equal 1
     end
 
+    it "should publish a draft block, without creating a version, when saving 1st draft version as published" do
+      draft_block.save.must_equal true
+      draft_block.must_be_published
+      draft_block.versions.size.must_equal 1
+    end
+
     it "should return false if there was no draft copy to publish" do
       block.publish.must_equal false
       block.must_be_published


### PR DESCRIPTION
This change allows a draft version to be published from edit screen without having to make any changes.

Current problem to be fixed by this change:
- save item as draft.
- return to edit screen.
- attempt to save as published
  ==>  failure: no change, block remains in draft state.
- return to edit screen
- edit any field
- attempt to save as published
  ==> success
