### PR TITLE
add paperclip 3.4.1 to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'bluecloth', :groups=>[:development, :test] # For YARD
 
 gem "thin" # To avoid annoying Ruby 1.9.3/Rails/Webrick warnings - See http://stackoverflow.com/questions/7082364/what-does-warn-could-not-determine-content-length-of-response-body-mean-and-h
 
+gem 'paperclip', '~> 3.4.1'
 # For testing behavior in production
 group :production do
   gem 'uglifier'


### PR DESCRIPTION
For compatibility with Spree 2-2-4, BrowserCMS dependencies must include Paperclip 3.4.1. 
