### PR TITLE
Do not use params for attachment search

### DIFF
--- a/app/controllers/cms/content_controller.rb
+++ b/app/controllers/cms/content_controller.rb
@@ -150,7 +150,7 @@ module Cms
 
     def try_to_stream_file
       if is_file?
-        @attachment = Attachment.find_live_by_file_path(request.fullpath)
+        @attachment = Attachment.find_live_by_file_path(request.fullpath.split('?').first)
         send_attachment(@attachment)
       end
 


### PR DESCRIPTION
If a request comes in for document.pdf?utm_source=email strip out the get params and only search attachments for "document.pdf", not "document.pdf?utm_source=email"
